### PR TITLE
Fix installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Installation
 ------------
 
 1. cd "$HOME/.drush"
-2. composer global require "drush/config-extra"
+2. composer require "drush/config-extra"
 3. drush cc drush
 
 Resources


### PR DESCRIPTION
- Remove keyword 'global' from the 'composer require' command to prevent
  a failed installation when composer downloads the project to the global
  composer cache instead of into ~/.drush
