### PR TITLE
Support loading as a project dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
   "name": "drush/config-extra",
   "description": "Drush config-extra contains additional configuration Drush commands, notably config-merge.",
+  "type": "drupal-drush",
   "license": "GPL-2.0+",
   "keywords": ["drush"],
   "minimum-stability": "dev",


### PR DESCRIPTION
The commands can be added per-project via Compoers so that each developer doesn't have to individually install the command. See drupal-composer/drupal-project [composer.json#L72](https://github.com/drupal-composer/drupal-project/blob/8.x/composer.json#L72).